### PR TITLE
blocks fancy icons for Windows OS

### DIFF
--- a/core/renderer.go
+++ b/core/renderer.go
@@ -71,8 +71,8 @@ func (r *Renderer) Render(tmpl string, data interface{}) error {
 	r.resetPrompt(r.lineCount)
 	// render the template summarizing the current state
 
-	// set Fancy icons if this is a real terminal
-	if isatty.IsTerminal(r.stdio.Out.Fd()) {
+	// set Fancy icons if this is a real terminal and not Windows
+	if isatty.IsTerminal(r.stdio.Out.Fd()) && !isatty.IsCygwinTerminal(r.stdio.Out.Fd()) {
 		SetFancyIcons()
 	}
 


### PR DESCRIPTION
This change may not be the right fix. It will block "fancy" icons in Windows. Many of the fancy icons are not included by default in Windows, for example the checkmark:

![image](https://user-images.githubusercontent.com/2105302/67704197-e4fe4300-f971-11e9-9aa7-71ff765579fc.png)
