### PR TITLE
fixes space issue in input template

### DIFF
--- a/input.go
+++ b/input.go
@@ -39,7 +39,7 @@ var InputQuestionTemplate = `
 {{- if .ShowAnswer}}{{- color "default"}}: {{color "reset"}}{{color "cyan"}}{{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else }}
   {{- if and .Help (not .ShowHelp)}}{{color "cyan"}}[{{ HelpInputRune }} for help]{{color "reset"}} {{end}}
-  {{- if .Default}}{{color "cyan+h"}}({{.Default}}) {{color "reset"}}{{end}}
+  {{- if .Default}}{{color "cyan+h"}} ({{.Default}}){{color "reset"}}{{end}}
 	{{- if not .ShowAnswer}}: {{end}}{{- color "cyan"}}
 {{- end}}`
 


### PR DESCRIPTION
This change puts a space between the question and default values when asking a user for input.

This is the solved state:
![image](https://user-images.githubusercontent.com/2105302/71044262-0fed5380-20e6-11ea-83e0-66a3f27c76ae.png)
